### PR TITLE
Fix spacing under section titles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -112,7 +112,7 @@
   }
 
   .section-title {
-    @apply text-3xl md:text-4xl font-bold mb-8 text-center text-gpttext relative;
+    @apply text-3xl md:text-4xl font-bold mb-8 text-center text-gpttext relative pb-2;
   }
 
   .section-title::after {


### PR DESCRIPTION
## Summary
- add padding below `.section-title` to keep text from crowding decorative underline

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847e13b9b308324a9121cb000721020